### PR TITLE
[0.3] Backpack/CRUD 3.3 support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ codestyle:
   image: novius/cs
   script:
     - export COMPOSER_HOME=/tmp/
-    - composer global require friendsofphp/php-cs-fixer:~2.6.0
+    - composer global require friendsofphp/php-cs-fixer:~2.8.0
     - $COMPOSER_HOME/vendor/bin/php-cs-fixer fix --config .php_cs -vv --diff --dry-run --allow-risky=yes
     - npm install --only=dev
     - sh ./cs.sh

--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ In your terminal:
 composer require novius/laravel-backpack-menu
 ```
 
-In `config/app.php`, add:
+Then, if you are on Laravel 5.4 (no need for Laravel 5.5 and higher), register the service provider to your `config/app.php` file:
 
 ```php
 Novius\Backpack\Menu\MenuServiceProvider::class
 ```
 
-Execute:
+Finally, run:
+
 ```bash
 php artisan vendor:publish --provider="Novius\Backpack\Menu\MenuServiceProvider" --tag="routes"
 php artisan vendor:publish --provider="Novius\Backpack\Menu\MenuServiceProvider" --tag="lang"

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
   ],
   "require": {
     "php": ">=7.1",
-    "laravel/framework": "~5.4.0|~5.5.0",
-    "novius/laravel-backpack-crud-extended": "~0.2.3"
+    "laravel/framework": "~5.5.0",
+    "novius/laravel-backpack-crud-extended": "~0.3.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "~2.5.0",
+    "friendsofphp/php-cs-fixer": "~2.8.0",
     "mockery/mockery": "^1.0",
-    "orchestra/testbench": "~3.0",
-    "phpunit/phpunit": "~5.7"
+    "orchestra/testbench": "~3.5",
+    "phpunit/phpunit": "~6.0"
   },
   "autoload": {
     "psr-4": {
@@ -48,7 +48,7 @@
   "extra": {
     "laravel": {
       "providers": [
-        "Novius\\Menu\\MenuServiceProvider"
+        "Novius\\Backpack\\Menu\\MenuServiceProvider"
       ]
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "Backpack"
   ],
   "type": "library",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "authors": [
     {
       "name": "Novius Agency",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
       "php-cs-fixer fix --dry-run --config .php_cs -vv --diff --allow-risky=yes"
     ],
     "test": [
-      "phpunit"
+      "phpunit --testdox"
     ]
   },
   "extra": {

--- a/config/laravel-backpack-menu.php
+++ b/config/laravel-backpack-menu.php
@@ -20,7 +20,7 @@ return [
      */
 
     'linkableObjects' => [
-        'App\Models\Page' => 'Page',
+        \App\Models\Page::class => 'Page',
     ],
 
     /*

--- a/src/Http/Controllers/Admin/Menu/ItemController.php
+++ b/src/Http/Controllers/Admin/Menu/ItemController.php
@@ -15,11 +15,11 @@ class ItemController extends CrudController
 {
     public function setup()
     {
-        $menuId = Request::input('menu');
+        $menuId = (int) Request::input('menu');
 
         $this->crud->setModel(Item::class);
         $this->crud->setRoute(route('crud.item.index'));
-        $this->crud->setIndexRoute('crud.item.index', ['menu' => (int) request('menu')]);
+        $this->crud->setIndexRoute('crud.item.index', ['menu' => $menuId]);
         $this->crud->setEntityNameStrings(trans('laravel-backpack-menu::menu.item'), trans('laravel-backpack-menu::menu.items'));
         $this->crud->setEditView('laravel-backpack-menu::edit');
 

--- a/src/Http/Controllers/Admin/Menu/ItemController.php
+++ b/src/Http/Controllers/Admin/Menu/ItemController.php
@@ -18,7 +18,8 @@ class ItemController extends CrudController
         $menuId = Request::input('menu');
 
         $this->crud->setModel(Item::class);
-        $this->crud->setRoute(route('crud.item.index', ['menu' => $menuId]));
+        $this->crud->setRoute(route('crud.item.index'));
+        $this->crud->setIndexRoute('crud.item.index', ['menu' => (int) request('menu')]);
         $this->crud->setEntityNameStrings(trans('laravel-backpack-menu::menu.item'), trans('laravel-backpack-menu::menu.items'));
         $this->crud->setEditView('laravel-backpack-menu::edit');
 

--- a/src/MenuServiceProvider.php
+++ b/src/MenuServiceProvider.php
@@ -15,6 +15,8 @@ class MenuServiceProvider extends LaravelServiceProvider
      */
     public function boot()
     {
+        $this->setupRoutes();
+
         $packageDir = dirname(__DIR__);
 
         $this->publishes([$packageDir.'/config' => config_path('backpack')], 'config');
@@ -36,7 +38,7 @@ class MenuServiceProvider extends LaravelServiceProvider
      */
     public function register()
     {
-        $this->setupRoutes();
+        //
     }
 
     /**


### PR DESCRIPTION
This PR adds Backpack\CRUD v3.3.* supports (and drop Laravel 5.4 support).