### PR TITLE
[0.3] Fix migration 2017_10_12_083439_alter__items_make_items_nullable.php

### DIFF
--- a/database/migrations/2017_10_12_083439_alter__items_make_items_nullable.php
+++ b/database/migrations/2017_10_12_083439_alter__items_make_items_nullable.php
@@ -26,7 +26,7 @@ class AlterItemsMakeItemsNullable extends Migration
     public function down()
     {
         Schema::table('novius_menu_items', function (Blueprint $table) {
-            $table->dropColumn('links');
+            $table->string('links');
         });
     }
 }


### PR DESCRIPTION
The `down` must be the inverse of `up`, so recreate the field, not drop it.