### PR TITLE
Fix delete of a menu's item

### DIFF
--- a/resources/views/buttons/delete.blade.php
+++ b/resources/views/buttons/delete.blade.php
@@ -1,3 +1,0 @@
-@if ($crud->hasAccess('delete'))
-	<a href="{{ url('admin/item/'.$entry->getKey()) }}" class="btn btn-xs btn-default" data-button-type="delete"><i class="fa fa-trash"></i> {{ trans('backpack::crud.delete') }}</a>
-@endif

--- a/src/Http/Controllers/Admin/Menu/ItemController.php
+++ b/src/Http/Controllers/Admin/Menu/ItemController.php
@@ -39,7 +39,6 @@ class ItemController extends CrudController
         $this->crud->addButton('top', 'reorder', 'view', 'laravel-backpack-menu::buttons.reorder', 'end');
 
         $this->crud->addButton('line', 'update', 'view', 'laravel-backpack-menu::buttons.update');
-        $this->crud->addButton('line', 'delete', 'view', 'laravel-backpack-menu::buttons.delete');
 
         $this->crud->addColumn([
             'name' => 'name',


### PR DESCRIPTION
The current delete button view made a GET request on `admin/item/{id}`, which corresponds to the route `show` of the Crud controller, on which there are no permissions, the `laravel-backpack-crud-extended` plugin does not manage the permissions on `show`.

When we try to delete an item, we receive à 403 response.

This PR just remove the overload of delete on each CRUD item line, and let Backpack manage the delete button.